### PR TITLE
Fix issue with links on mobile menu

### DIFF
--- a/src/components/Title/index.js
+++ b/src/components/Title/index.js
@@ -44,7 +44,7 @@ export default function Title() {
   const below1080 = useMedia('(max-width: 1080px)')
 
   return (
-    <TitleWrapper onClick={() => history.push('/')}>
+    <TitleWrapper>
       <Flex alignItems="center" style={{ justifyContent: 'space-between' }}>
         <RowFixed>
           <UniIcon id="link" onClick={() => history.push('/')}>


### PR DESCRIPTION
Links keep redirecting to home, i figured this was because of the onClick handler on TitleWrapper, removing this, fixed the issue. Tested this and nothing seems broken so far